### PR TITLE
Text injection fixes

### DIFF
--- a/components/ConnectDiscordButton.tsx
+++ b/components/ConnectDiscordButton.tsx
@@ -1,28 +1,23 @@
-import React, { useState, useEffect } from "react";
-import { toast } from "react-toastify";
-import { ConnectButton } from "@rainbow-me/rainbowkit";
+import React from "react";
 import Button from "./button";
-import HStack from "./hstack";
-import pkceChallenge from "pkce-challenge";
 import { stringify } from "querystring";
 import { useAccount } from "wagmi";
+import { ConnectedApp } from "./LinkedAccountInfo";
 
-type ConnectDiscordProps = {
-}
-
-const ConnectDiscordButton = ({ }: ConnectDiscordProps) => {
-    const [isTwitterConnected, setTwitterConnected] = useState(false);
-
-    const { address } = useAccount();
+const ConnectDiscordButton: React.FC = () => {
+  const { address } = useAccount();
 
     const verifyDiscord = async () => {
-        const oAuthScope = ["identify"].join(" ");
         const oAuthData = new URLSearchParams({
+            scope: "identify",
             response_type: "code",
             client_id: process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID as string,
             redirect_uri: `${process.env.NEXT_PUBLIC_VERIFIER_URI}/api/v1/verify`, // endpoint must be added https://discord.com/developers/applications (see Oauth2 -> redirects)
-            scope: oAuthScope,
-            state: stringify({ recipient: address, app: 'discord', client_uri: window.location.origin })
+            state: stringify({
+                app: ConnectedApp.Discord,
+                recipient: address,
+                client_uri: window.location.origin,
+            }),
         });
 
         window.location.href = `https://discordapp.com/oauth2/authorize?${oAuthData}`

--- a/components/ConnectTwitterButton.tsx
+++ b/components/ConnectTwitterButton.tsx
@@ -1,21 +1,13 @@
-import React, { useState, useEffect } from "react";
-import { toast } from "react-toastify";
-import { ConnectButton } from "@rainbow-me/rainbowkit";
+import React from "react";
 import Button from "./button";
-import HStack from "./hstack";
 import pkceChallenge from "pkce-challenge";
 import { stringify } from "querystring";
 import { useAccount } from "wagmi";
+import { ConnectedApp } from "./LinkedAccountInfo";
 
-type ConnectTwitterButtonProps = {
-    buttonType?: 'primary' | 'secondary'
-}
-
-const ConnectTwitterButton = ({ buttonType = 'primary' }: ConnectTwitterButtonProps) => {
-    const [isTwitterConnected, setTwitterConnected] = useState(false);
-
+const ConnectTwitterButton: React.FC = () => {
     const { address } = useAccount();
-    
+
     const verifyTwitter = async () => {
         const pkce = pkceChallenge();
 
@@ -27,7 +19,7 @@ const ConnectTwitterButton = ({ buttonType = 'primary' }: ConnectTwitterButtonPr
             scope: oAuthScope,
             code_challenge: pkce.code_challenge,
             code_challenge_method: "plain",
-            state: stringify({ recipient: address, app: 'twitter', client_uri: window.location.origin, code_verifier: pkce.code_challenge })
+            state: stringify({ recipient: address, app: ConnectedApp.Twitter, client_uri: window.location.origin, code_verifier: pkce.code_challenge })
         });
 
         window.location.href = `https://twitter.com/i/oauth2/authorize?${oAuthData}`

--- a/components/LinkedAccountInfo.tsx
+++ b/components/LinkedAccountInfo.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, Dispatch } from "react";
+import React, { ReactNode } from "react";
 import styles from "css/modules/accountBanner.module.scss";
 import classNames from "classnames";
 import { BigNumber } from "ethers";
@@ -7,6 +7,11 @@ type AccountBannerProps = {
     children: ReactNode;
     isVisible: boolean;
 };
+
+export enum ConnectedApp {
+  Discord = 'discord',
+  Twitter = 'twitter'
+}
 
 const AccountBanner = ({ children, isVisible }: AccountBannerProps) => {
     return (
@@ -24,7 +29,7 @@ export const AccountContext = React.createContext<
         userid?: string,
         fee?: BigNumber,
         recipient?: string,
-        app?: string,
+        app?: ConnectedApp,
         verifier?: string,
         verifySig?: string,
         setUsername: (_: string) => void,
@@ -33,7 +38,7 @@ export const AccountContext = React.createContext<
         setUserid: (_: string) => void,
         setFee: (_: BigNumber) => void,
         setRecipient: (_: string) => void,
-        setApp: (_: string) => void,
+        setApp: (_: ConnectedApp) => void,
         setVerifier: (_: string) => void,
         setVerifySig: (_: string) => void,
     }

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,13 +1,11 @@
-
 import classnames from 'classnames';
-
 
 import { upperFirst } from "lodash";
 import { useRouter } from 'next/router';
 import styles from "../css/modules/layout.module.scss";
 import Header from "./header";
 import HStack, { StackGapSize } from './hstack';
-import AccountBanner, { AccountContext } from './LinkedAccountInfo';
+import AccountBanner, { AccountContext, ConnectedApp } from "./LinkedAccountInfo";
 import { MintContext } from './mint';
 import NFTViewer from './NftViewer';
 import VStack from './vstack';
@@ -28,12 +26,15 @@ const HelixLayout = ({ children }: LayoutType) => {
 
     const username = (account) => {
         if (!account.username) {
-            return ""
+            return "";
         }
-        return `${account.app === "twitter" ? "@" : ""}${account.username}`;
+        return `${account.app === ConnectedApp.Twitter ? "@" : ""}${account.username}`;
     }
 
     const userId = (account) => {
+        if (isNaN(account.userid)) {
+            return "";
+        }
         const id = account.userid as string;
         return `${id.slice(0, 4)} •••• ${id.slice(id.length - 4, id.length)}`;
     }
@@ -75,7 +76,7 @@ const HelixLayout = ({ children }: LayoutType) => {
                                     </HStack>
 
                                     <HStack>
-                                        <p>{userId(account)} <span className="text-color-light">({username(account)})</span></p>
+                                        <p>{userId(account)}</p>
                                     </HStack>
                                     <HStack>
                                         <p className="text-color-light text-size-small"><a className="text-color-normal" onClick={handleDisconnect} href="#">Disconnect</a></p>

--- a/pages/error.tsx
+++ b/pages/error.tsx
@@ -29,14 +29,16 @@ const Error: NextPage = () => {
 
     useEffect(() => {
         if (router.query && router.query.errorCode) {
-
             const code = router.query.errorCode as string;
 
             // get description based on error code
-            let description = EcoErrors[code] || "";
-
-            setError({ code, description });
-
+            let description = EcoErrors[code];
+            if (description) {
+                setError({ 
+                    code, 
+                    description
+                });
+            }
         }
     }, [router.query]);
 
@@ -48,15 +50,13 @@ const Error: NextPage = () => {
             <div className="flex justify-center">
                 <div className="w-7/12 max-w-4xl flex flex-col gap-6 text-lg text-center">
                     <div className="text-3xl font-medium mb-2" >Something went wrong while verifying your account</div>
+                    <br/>
                     {error && (
                         <div className="text-xl font-small mb-2" >
                             {error.description}
-                            <br />
-                            <br />
-                            Code: {error.code}
                         </div>
-
                     )}
+                    <br/>
                     <div className="align-center">
                         <Link href="/" >
                             <button>Back to Home</button>


### PR DESCRIPTION
Added validation for certain query parameters that are directly displayed so that they cannot be replaced by some arbitrary text:

## Mint flow
### `userid`
Must be numerical, if discord, must be between 3 and 32 characters in length

### `app` 
Must be one of `discord` or `twitter`

### `username`
Length must be a within a certain range depending on if it is from discord or twitter, if twitter, must not have any whitespace.

## Error flow
### `errorCode`
Error code is no longer displayed by itself, only the description that matches the code will be displayed, if no description exists for the code given, no description is displayed
